### PR TITLE
Port in zenburn colours for org-habit

### DIFF
--- a/leuven-dark-theme.el
+++ b/leuven-dark-theme.el
@@ -766,6 +766,15 @@ more...")
    `(org-example ((,class (:foreground "#ffff0b" :background "#38203d"))))
    `(org-footnote ((,class (:underline t :foreground "#ff7138"))))
    `(org-formula ((,class (:foreground "#0680e1"))))
+   ;; org-habit colours are thanks to zenburn
+   `(org-habit-ready-face ((t :background "#7F9F7F"))) ; ,zenburn-green
+   `(org-habit-alert-face ((t :background "#E0CF9F" :foreground "#3F3F3F"))) ; ,zenburn-yellow-1 fg ,zenburn-bg
+   `(org-habit-clear-face ((t :background "#5C888B")))                       ; ,zenburn-blue-3
+   `(org-habit-overdue-face ((t :background "#9C6363")))                     ; ,zenburn-red-3
+   `(org-habit-clear-future-face ((t :background "#4C7073")))                ; ,zenburn-blue-4
+   `(org-habit-ready-future-face ((t :background "#5F7F5F")))                ; ,zenburn-green-2
+   `(org-habit-alert-future-face ((t :background "#D0BF8F" :foreground "#3F3F3F"))) ; ,zenburn-yellow-2 fg ,zenburn-bg
+   `(org-habit-overdue-future-face ((t :background "#8C5353"))) ; ,zenburn-red-4
    `(org-headline-done ((,class (:height 1.0 :weight normal :strike-through t :foreground "#57525c"))))
    `(org-hide ((,class (:foreground "#403b45"))))
    `(org-inlinetask ((,class (:box (:line-width 1 :color "#37323c") :foreground "#8c8890" :background "#252050"))))

--- a/leuven-theme.el
+++ b/leuven-theme.el
@@ -768,6 +768,15 @@ more...")
    `(org-example ((,class (:foreground "blue" :background "#EAFFEA"))))
    `(org-footnote ((,class (:underline t :foreground "#008ED1"))))
    `(org-formula ((,class (:foreground "chocolate1"))))
+   ;; org-habit colours are thanks to zenburn
+   `(org-habit-ready-face ((t :background "#7F9F7F"))) ; ,zenburn-green
+   `(org-habit-alert-face ((t :background "#E0CF9F" :foreground "#3F3F3F"))) ; ,zenburn-yellow-1 fg ,zenburn-bg
+   `(org-habit-clear-face ((t :background "#5C888B")))                       ; ,zenburn-blue-3
+   `(org-habit-overdue-face ((t :background "#9C6363")))                     ; ,zenburn-red-3
+   `(org-habit-clear-future-face ((t :background "#4C7073")))                ; ,zenburn-blue-4
+   `(org-habit-ready-future-face ((t :background "#5F7F5F")))                ; ,zenburn-green-2
+   `(org-habit-alert-future-face ((t :background "#D0BF8F" :foreground "#3F3F3F"))) ; ,zenburn-yellow-2 fg ,zenburn-bg
+   `(org-habit-overdue-future-face ((t :background "#8C5353"))) ; ,zenburn-red-4
    `(org-headline-done ((,class (:height 1.0 :weight normal :foreground "#ADADAD"))))
    `(org-hide ((,class (:foreground "#E2E2E2"))))
    `(org-inlinetask ((,class (:box (:line-width 1 :color "#EBEBEB") :foreground "#777777" :background "#FFFFD6"))))


### PR DESCRIPTION
The org-habit visualization does not display so well in Leuven or Leuven Dark, so I brought over the zenburn colours.

This is not just an issue of appearance, the current colours in Leuven really complicate the interpretation of the habit graphs.

Also, leuven currently has no explicit choices for any of the `org-habit-*` colours.

## Before

![image](https://user-images.githubusercontent.com/937871/86537103-f29a9e00-beec-11ea-8683-3df45ec2f679.png)

![image](https://user-images.githubusercontent.com/937871/86537107-f62e2500-beec-11ea-82a0-11871c44cb3d.png)

## After

![image](https://user-images.githubusercontent.com/937871/86537130-13fb8a00-beed-11ea-9c23-c5c55e0fdf09.png)

![image](https://user-images.githubusercontent.com/937871/86537137-1d84f200-beed-11ea-8ca6-2366a1f004c7.png)
