### PR TITLE
Add autoload in `leuven-theme.el`

### DIFF
--- a/lisp/leuven-theme.el
+++ b/lisp/leuven-theme.el
@@ -81,6 +81,7 @@ number."
           (const :tag "Default provided by theme" t)
           (number :tag "Set scaling")))
 
+;;;###autoload
 (defun leuven-scale-font (control default-height)
   "Function for splicing optional font heights into face descriptions.
 CONTROL can be a number, nil, or t.  When t, use DEFAULT-HEIGHT."


### PR DESCRIPTION
I'm using [borg](https://github.com/emacscollective/borg) to
manage my packages, adding `autoload` comment will silence the
compile warning since `leuven-theme-dark` is compiled before
`leuven-theme` according to their name.


<img width="658" alt="Snipaste_2021-06-02_09-40-02" src="https://user-images.githubusercontent.com/25452934/120411599-a3bce900-c387-11eb-95cb-baeb7f974194.png">
