### PR TITLE
Set version to 1.0 for GNU ELPA addition

### DIFF
--- a/lisp/leuven-dark-theme.el
+++ b/lisp/leuven-dark-theme.el
@@ -5,7 +5,7 @@
 ;; Author: Fabrice Niessen <(concat "fniessen" at-sign "pirilampo.org")>
 ;; Contributor: Thibault Polge <(concat "thibault" at-sign "thb.lt")>
 ;; URL: https://github.com/fniessen/emacs-leuven-theme
-;; Version: 20220203.1046
+;; Version: 1.0
 ;; Keywords: color theme
 
 ;; This file is part of GNU Emacs.
@@ -1084,12 +1084,5 @@ more...")
                (file-name-as-directory (file-name-directory load-file-name))))
 
 (provide-theme 'leuven-dark)
-
-;; This is for the sake of Emacs.
-;; Local Variables:
-;; time-stamp-end: "$"
-;; time-stamp-format: "%:y%02m%02d.%02H%02M"
-;; time-stamp-start: "Version: "
-;; End:
 
 ;;; leuven-dark-theme.el ends here

--- a/lisp/leuven-theme.el
+++ b/lisp/leuven-theme.el
@@ -4,7 +4,7 @@
 
 ;; Author: Fabrice Niessen <(concat "fniessen" at-sign "pirilampo.org")>
 ;; URL: https://github.com/fniessen/emacs-leuven-theme
-;; Version: 20210507.1750
+;; Version: 1.0
 ;; Keywords: color theme
 
 ;; This file is part of GNU Emacs.
@@ -1106,12 +1106,5 @@ more...")
                (file-name-as-directory (file-name-directory load-file-name))))
 
 (provide-theme 'leuven)
-
-;; This is for the sake of Emacs.
-;; Local Variables:
-;; time-stamp-end: "$"
-;; time-stamp-format: "%:y%02m%02d.%02H%02M"
-;; time-stamp-start: "Version: "
-;; End:
 
 ;;; leuven-theme.el ends here


### PR DESCRIPTION
This adds the version number, like we discussed in #96. Let me know if you want some other version than `1.0`.