### PR TITLE
Removing inherit property for coe-inline in order to avoid alignment problems in tables

### DIFF
--- a/lisp/leuven-theme.el
+++ b/lisp/leuven-theme.el
@@ -111,7 +111,7 @@ more...")
       (cancel '(:slant italic :strike-through t :foreground "#A9A9A9"))
       ;; (clock-line '(:box (:line-width 1 :color "#335EA8") :foreground "black" :background "#EEC900"))
       (code-block '(:foreground "#000088" :background "#FFFFE0"))
-      (code-inline '(:foreground "#006400" :background "#F4FFF4" :inherit fixed-pitch-serif))
+      (code-inline '(:foreground "#006400" :background "#F4FFF4"))
       (column '(:height 1.0 :weight normal :slant normal :underline nil :strike-through unspecified :foreground "#E6AD4F" :background "#FFF2DE"))
       (completion-inline '(:weight normal :foreground "#C0C0C0" :inherit hl-line)) ; Like Google.
       (completion-other-candidates '(:foreground "black" :background "#F7F7F7"))


### PR DESCRIPTION
Inline code in tables leads to misalignment as such:
<img width="302" height="119" alt="image" src="https://github.com/user-attachments/assets/7984a756-09c6-485c-a009-68461a49e1ea" />

It should be

<img width="294" height="114" alt="image" src="https://github.com/user-attachments/assets/b618aeb6-cf8c-4138-a049-3804baeba9b3" />

This PR fixes this problem akin to how things are defined in the dark theme.